### PR TITLE
docs: add more details in commit message convention

### DIFF
--- a/dev-guide.md
+++ b/dev-guide.md
@@ -3,33 +3,41 @@
 ## Commit Message Convention
 
 ```
-<type>: do something
+<type>: <subject>
 ```
 
 or
 
 ```
-<type>: do something
+<type>: <subject>
 
-It does something.
+<description>
 ```
 
-- Use imperative mood.
-- Omit articles (`a/an` and `the`).
 - Always put the proper `<type>`
+- `<subject>`
+  - summarize your change
+  - use imperative mood.
+  - Omit articles (`a/an` and `the`).
+  - should not exceed 75 characters
+  - must start with lowercase
+- `<description>` 
+  - detailed explantion of your change
 
 ### Types
 From [angular project](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)
 
-1. build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-1. ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-1. docs: Documentation only changes
-1. feat: A new feature
-1. fix: A bug fix
-1. perf: A code change that improves performance
-1. refactor: A code change that neither fixes a bug nor adds a feature
-1. style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-1. test: Adding missing tests or correcting existing tests
+1. build: Changes that affect the build system or external dependencies 
+2. ci: Changes to our CI configuration files and scripts 
+3. docs: Documentation only changes
+4. feat: A new feature
+5. fix: A bug fix
+6. perf: A code change that improves performance
+7. refactor: A code change that neither fixes a bug nor adds a feature
+8. style: Changes that do not affect the meaning of the code 
+9. test: Adding missing tests or correcting existing tests
+10. revert: Revert commit it should begin with `revert: `, followed by the header of the reverted commit. 
+`<description>` must contain `This reverts commit <hash>.`
 
 ### Examples
 ```


### PR DESCRIPTION
커밋 메세지에 몇가지 컨벤션을 추가했습니다. 
  - subject 와 description 에 대해 스타일적인 설명 추가
  - 길이 제한
  - 첫 글자 소문자로 고정
  - `revert: ` 타입 추가